### PR TITLE
Make library usable

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 # don't lint build output (make sure it's set to your correct build folder name)
 dist
+jest.config.js

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "gorsejs",
   "description": "",
   "version": "0.4.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "license": "Apache-2.0",
   "repository": "git://github.com/gorse-io/gorse-js",
   "homepage": "https://github.com/gorse-io/gorse-js",


### PR DESCRIPTION
Define main file and types so the library can actually be used. (Also ignored jest config because eslint didn't like it.)