### PR TITLE
auto build .npmignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,3 +247,6 @@ fabric.properties
 # .pnp.*
 
 # End of https://www.toptal.com/developers/gitignore/api/yarn,node,webstorm+all
+
+# Npmignore
+.npmignore

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "build": "rimraf dist && tsc --build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "jest"
+    "test": "jest",
+    "prepack": "npmignore --auto"
   },
   "dependencies": {
     "axios": "^0.27.0",
@@ -41,11 +42,17 @@
     "jest": "^28.1.3",
     "jsdoc": "^3.6.0",
     "nodemon": "^2.0.16",
+    "npmignore": "^0.3.0",
     "prettier": "^2.6.0",
     "redis": "^4.2.0",
     "rimraf": "^3.0.0",
     "ts-jest": "^28.0.7",
     "ts-node": "^10.8.1",
     "typescript": "^4.7.4"
+  },
+  "publishConfig": {
+    "ignore": [
+      "!dist/"
+    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2535,6 +2535,11 @@ minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+
 mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
@@ -2599,6 +2604,13 @@ npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+npmignore@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/npmignore/-/npmignore-0.3.0.tgz#1431207b2fb9912e5f98706717267543c04169d1"
+  integrity sha512-lJw7pfo+dqj/scV5s+3SWpEuLAgJHVPs3vJ/B8FzA8zYQLiTs+TnPiQTYNCu1KPMuDaGm/U5DRItJ7xYb2qVGQ==
+  dependencies:
+    minimist "^1.2.6"
 
 once@^1.3.0:
   version "1.4.0"


### PR DESCRIPTION
This is a just a solution to #3 that i've found to be useful in my own projects. Builds `.npmignore` file based on a config in the `package.json` and the `.gitignore`. Fixes #3.