### PR TITLE
Session recommendations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,4 +10,3 @@ trim_trailing_whitespace = true
 
 [*.md]
 max_line_length = 0
-trim_trailing_whitespace = true

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,4 @@
 {
-    "tabWidth": 2,
-    "useTabs": false
-  }
-  
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,6 +7,7 @@ import {
 } from "axios-logger";
 import {
   FeedbackFilter,
+  GorseException,
   ItemNeighborsOptions,
   PopularOptions,
   RecommendOptions,
@@ -78,6 +79,16 @@ class Gorse<T extends string> {
       this.axiosClient.interceptors.request.use(requestLogger, errorLogger);
       this.axiosClient.interceptors.response.use(responseLogger, errorLogger);
     }
+
+    this.axiosClient.interceptors.response.use(undefined, (error) => {
+      // HTTP errors
+      if ("response" in error) {
+        const { response } = error;
+        throw new GorseException(response.status, response.data);
+      }
+      // Network errors
+      throw new GorseException(-1, error.message);
+    });
   }
 
   // Core functions

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,6 +11,7 @@ import {
   ItemNeighborsOptions,
   PopularOptions,
   RecommendOptions,
+  SessionRecommendOptions,
   UserNeighborsOptions,
 } from ".";
 import {
@@ -48,7 +49,12 @@ import {
   insertUsers,
   updateUser,
 } from "./model/user";
-import { getLatest, getPopular, getRecommend } from "./model/recommend";
+import {
+  getLatest,
+  getPopular,
+  getRecommend,
+  getSessionRecommend,
+} from "./model/recommend";
 
 export { Item, User, Feedback } from "./interfaces";
 
@@ -103,6 +109,13 @@ class Gorse<T extends string> {
 
   getRecommend(options: RecommendOptions) {
     return getRecommend(this.axiosClient, options);
+  }
+
+  getSessionRecommend(
+    feedbackList: Feedback<T>[],
+    options: SessionRecommendOptions = {}
+  ) {
+    return getSessionRecommend(this.axiosClient, feedbackList, options);
   }
 
   // Feedback

--- a/src/error.ts
+++ b/src/error.ts
@@ -2,6 +2,7 @@ export class GorseException extends Error {
   code: number;
   constructor(code: number, message: string) {
     super(message);
+    this.name = "GorseException";
     this.code = code;
   }
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -35,6 +35,11 @@ export interface RecommendOptions {
   cursorOptions?: OffsetCursorOptions;
 }
 
+export interface SessionRecommendOptions {
+  category?: string;
+  cursorOptions?: OffsetCursorOptions;
+}
+
 export interface ItemNeighborsOptions {
   itemId: string;
   category?: string;

--- a/src/model/feedback.ts
+++ b/src/model/feedback.ts
@@ -1,5 +1,4 @@
 import { AxiosInstance, AxiosResponse } from "axios";
-import { GorseException } from "../error";
 import {
   CursorOptions,
   Feedback,
@@ -23,10 +22,6 @@ export function getFeedback<T extends string>(
     )
     .then(({ data }) => {
       return data;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -40,10 +35,6 @@ export function deleteFeedback<T extends string>(
     )
     .then(({ data }) => {
       return data;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -60,10 +51,6 @@ export function getFeedbacksByType<T extends string>(
     )
     .then(({ data }) => {
       return data;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -77,10 +64,6 @@ export function getFeedbacks<T extends string>(
     })
     .then(({ data }) => {
       return data;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -92,10 +75,6 @@ export function insertFeedbacks<T extends string>(
     .post<Success, AxiosResponse<Success>>(`/feedback`, feedbacksList)
     .then(({ data }) => {
       return data.RowAffected;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -107,10 +86,6 @@ export function upsertFeedbacks<T extends string>(
     .put<Success, AxiosResponse<Success>>(`/feedback`, feedbacksList)
     .then(({ data }) => {
       return data.RowAffected;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 

--- a/src/model/item.ts
+++ b/src/model/item.ts
@@ -1,5 +1,4 @@
 import { AxiosInstance, AxiosResponse } from "axios";
-import { GorseException } from "../error";
 import {
   CursorOptions,
   Success,
@@ -13,10 +12,6 @@ export function upsertItem(axios: AxiosInstance, itemData: Item) {
     .post<Success, AxiosResponse<Success>>(`/item`, itemData)
     .then(({ data }) => {
       return data.RowAffected;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -25,10 +20,6 @@ export function getItem(axios: AxiosInstance, itemId: string) {
     .get<Item, AxiosResponse<Item>>(`/item/${itemId}`)
     .then(({ data }) => {
       return data;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -37,10 +28,6 @@ export function deleteItem(axios: AxiosInstance, itemId: string) {
     .delete<Success, AxiosResponse<Success>>(`/item/${itemId}`)
     .then(({ data }) => {
       return data.RowAffected;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -53,10 +40,6 @@ export function updateItem(
     .patch<Success, AxiosResponse<Success>>(`/item/${itemId}`, itemData)
     .then(({ data }) => {
       return data.RowAffected;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -71,10 +54,6 @@ export function insertItemCategory(
     )
     .then(({ data }) => {
       return data.RowAffected;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -89,10 +68,6 @@ export function deleteItemCategory(
     )
     .then(({ data }) => {
       return data.RowAffected;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -103,10 +78,6 @@ export function getItems(axios: AxiosInstance, options?: CursorOptions) {
     })
     .then(({ data }) => {
       return data;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -115,10 +86,6 @@ export function upsertItems(axios: AxiosInstance, items: Item[]) {
     .post<Success, AxiosResponse<Success>>(`/items`, items)
     .then(({ data }) => {
       return data.RowAffected;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -135,9 +102,5 @@ export function getItemNeighbors(
     )
     .then(({ data }) => {
       return data;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }

--- a/src/model/recommend.ts
+++ b/src/model/recommend.ts
@@ -1,9 +1,11 @@
 import { AxiosInstance, AxiosResponse } from "axios";
 import {
+  Feedback,
   LatestOutput,
   PopularOptions,
   PopularOutput,
   RecommendOptions,
+  SessionRecommendOptions,
 } from "../interfaces";
 
 export function getPopular(
@@ -56,6 +58,22 @@ export function getRecommend(
         },
       }
     )
+    .then(({ data }) => {
+      return data;
+    });
+}
+
+export function getSessionRecommend<T extends string>(
+  axios: AxiosInstance,
+  feedbackList: Feedback<T>[] = [],
+  { category = "", cursorOptions }: SessionRecommendOptions
+) {
+  return axios
+    .post(`/session/recommend/${category}`, feedbackList, {
+      params: {
+        ...cursorOptions,
+      },
+    })
     .then(({ data }) => {
       return data;
     });

--- a/src/model/recommend.ts
+++ b/src/model/recommend.ts
@@ -1,5 +1,4 @@
 import { AxiosInstance, AxiosResponse } from "axios";
-import { GorseException } from "../error";
 import {
   LatestOutput,
   PopularOptions,
@@ -20,10 +19,6 @@ export function getPopular(
     )
     .then(({ data }) => {
       return data;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -37,10 +32,6 @@ export function getLatest(
     })
     .then(({ data }) => {
       return data;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -67,9 +58,5 @@ export function getRecommend(
     )
     .then(({ data }) => {
       return data;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }

--- a/src/model/user.ts
+++ b/src/model/user.ts
@@ -1,5 +1,4 @@
 import { AxiosInstance, AxiosResponse } from "axios";
-import { GorseException } from "../error";
 import {
   CursorOptions,
   Success,
@@ -14,10 +13,6 @@ export function insertUser(axios: AxiosInstance, userData: User) {
     .post<Success, AxiosResponse<Success>>(`/user`, userData)
     .then(({ data }) => {
       return data.RowAffected;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -26,10 +21,6 @@ export function getUser(axios: AxiosInstance, userId: string) {
     .get<User, AxiosResponse<User>>(`/user/${userId}`)
     .then(({ data }) => {
       return data;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -38,10 +29,6 @@ export function deleteUser(axios: AxiosInstance, userId: string) {
     .delete<Success, AxiosResponse<Success>>(`/user/${userId}`)
     .then(({ data }) => {
       return data.RowAffected;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -54,10 +41,6 @@ export function updateUser(
     .patch<Success, AxiosResponse<Success>>(`/user/${userId}`, userData)
     .then(({ data }) => {
       return data.RowAffected;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -68,10 +51,6 @@ export function getUsers(axios: AxiosInstance, options?: CursorOptions) {
     })
     .then(({ data }) => {
       return data;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -81,10 +60,6 @@ export function insertUsers(axios: AxiosInstance, users: User[]) {
     .post<Success, AxiosResponse<Success>>(`/users`, users)
     .then(({ data }) => {
       return data.RowAffected;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }
 
@@ -98,9 +73,5 @@ export function getUserNeighbors(
     })
     .then(({ data }) => {
       return data;
-    })
-    .catch((exception) => {
-      const { response } = exception;
-      return Promise.reject(new GorseException(response.status, response.data));
     });
 }

--- a/tests/gorse.test.ts
+++ b/tests/gorse.test.ts
@@ -116,3 +116,22 @@ test("test recommend", async () => {
   });
   expect(recommendedItems).toStrictEqual(["3", "2", "1"]);
 });
+
+test("test session recommend", async () => {
+  await redisClient.zAdd("item_neighbors/100", { score: 1, value: "200" });
+  const timestamp = "2022-08-07T00:26:46Z";
+  const recommendedItems = await client.getSessionRecommend([
+    {
+      FeedbackType: "like",
+      UserId: "400",
+      ItemId: "100",
+      Timestamp: timestamp,
+    },
+  ]);
+  expect(recommendedItems).toStrictEqual([
+    {
+      Id: "200",
+      Score: 1,
+    },
+  ]);
+});

--- a/tests/gorse.test.ts
+++ b/tests/gorse.test.ts
@@ -21,6 +21,15 @@ afterAll(async () => {
   await redisClient.disconnect();
 });
 
+test("connection error", async () => {
+  const client = new Gorse({
+    endpoint: "",
+    debug: true,
+  });
+
+  await expect(client.getPopular({})).rejects.toThrow(GorseException);
+});
+
 test("test users", async () => {
   // insert a user
   let rowAffected = await client.insertUser({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,11 @@
 {
-    "extends": "./tsconfig.base.json",
-    "compilerOptions": {
-      "composite": true,
-      "outDir": "./dist",
-      "rootDir": "./src",
-      "resolveJsonModule": true
-    },
-    "include": ["src"],
-    "exclude": ["node_modules"]
-  }
-  
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Fixes in this PR:
- Method to get session recomendations.
- Better handling of network eceptions. All network errors (e.g. `ECONNRESET`, `ECONNREFUSED`, `SELF_SIGNED_CERT_IN_CHAIN`) were muted, we got TypeError instead (see the screenshot). Now network errors are wrapped with GorseException as well as HTTP errors.
<img width="597" alt="Screenshot 2023-05-07 at 18 01 51" src="https://user-images.githubusercontent.com/9255915/236679273-dbf498cf-3077-4b09-a033-a21f2971e82c.png">


