### PR TITLE
feat: add SearchItems API

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -44,6 +44,7 @@ import {
   updateItem,
   getItems,
   getItemNeighbors,
+  searchItems,
 } from "./model/item";
 import {
   deleteUser,
@@ -190,6 +191,10 @@ class Gorse<T extends string> {
 
   getItems(options?: CursorOptions) {
     return getItems(this.axiosClient, options);
+  }
+
+  searchItems(query: string, n: number) {
+    return searchItems(this.axiosClient, query, n);
   }
 
   upsertItems(items: Item[]) {

--- a/src/model/item.ts
+++ b/src/model/item.ts
@@ -83,6 +83,19 @@ export function getItems(axios: AxiosInstance, options?: CursorOptions) {
     });
 }
 
+export function searchItems(axios: AxiosInstance, query: string, n: number) {
+  return axios
+    .get<ItemCursor, AxiosResponse<ItemCursor>>(`/items`, {
+      params: {
+        q: query,
+        n,
+      },
+    })
+    .then(({ data }) => {
+      return data;
+    });
+}
+
 export function upsertItems(axios: AxiosInstance, items: Item[]) {
   return axios
     .post<Success, AxiosResponse<Success>>(`/items`, items)

--- a/tests/gorse.test.ts
+++ b/tests/gorse.test.ts
@@ -119,6 +119,13 @@ test("test items", async () => {
   await expect(client.getItem("2000")).rejects.toThrow(GorseException);
 });
 
+test("test search items", async () => {
+  const resp = await client.searchItems("Toy Story", 3);
+  expect(resp.Items.length).toBeGreaterThan(0);
+  expect(resp.Items[0].ItemId).toBe("1");
+  expect(resp.Items[0].Comment).toBe("Toy Story (1995)");
+});
+
 test("test feedback", async () => {
   await client.insertUser({ UserId: "2000" });
 


### PR DESCRIPTION
## Summary
- add searchItems API for /api/items?q=...&n=...
- add integration test coverage based on gorse-go SearchItems behavior

## Tests
- corepack yarn lint
- corepack yarn build
- corepack yarn test (fails locally because Gorse is not running on 127.0.0.1:8088)