### PR TITLE
feat: support recommendation parameters

### DIFF
--- a/packages/gorsejs/src/interfaces.ts
+++ b/packages/gorsejs/src/interfaces.ts
@@ -24,12 +24,11 @@ export interface LatestOptions {
 
 export interface RecommendOptions {
   userId: string;
-  category?: string;
+  category?: string | string[];
   writeBackType?: string;
   writeBackDelay?: string;
   cursorOptions?: OffsetCursorOptions;
 }
-
 
 export interface SessionRecommendOptions {
   category?: string;

--- a/packages/gorsejs/src/model/recommend.ts
+++ b/packages/gorsejs/src/model/recommend.ts
@@ -24,21 +24,39 @@ export function getRecommend(
   axios: AxiosInstance,
   {
     userId,
-    category = "",
+    category,
     cursorOptions,
     writeBackType,
     writeBackDelay,
   }: RecommendOptions,
 ) {
+  const params = new URLSearchParams();
+  const categories = Array.isArray(category)
+    ? category
+    : category
+      ? [category]
+      : [];
+  for (const value of categories) {
+    params.append("category", value);
+  }
+  if (writeBackType) {
+    params.append("write-back-type", writeBackType);
+  }
+  if (writeBackDelay) {
+    params.append("write-back-delay", writeBackDelay);
+  }
+  if (cursorOptions?.n !== undefined) {
+    params.append("n", cursorOptions.n.toString());
+  }
+  if (cursorOptions?.offset !== undefined) {
+    params.append("offset", cursorOptions.offset.toString());
+  }
+
   return axios
     .get<Score[], AxiosResponse<Score[]>>(
-      `/recommend/${userId}/${category}`,
+      `/recommend/${encodeURIComponent(userId)}`,
       {
-        params: {
-          ...(writeBackType ? { "write-back-type": writeBackType } : {}),
-          ...(writeBackDelay ? { "write-back-delay": writeBackDelay } : {}),
-          ...cursorOptions,
-        },
+        params,
         headers: {
           "X-API-Version": "2",
         },

--- a/packages/gorsejs/tests/gorse.test.ts
+++ b/packages/gorsejs/tests/gorse.test.ts
@@ -200,3 +200,23 @@ test("test recommend", async () => {
   expect(recommendations[1].Id).toBe("1432");
   expect(recommendations[2].Id).toBe("918");
 });
+
+test("test recommend with multiple categories", async () => {
+  await client.insertUser({ UserId: "4000" });
+  const recommendations = await client.getRecommend({
+    userId: "4000",
+    category: ["Drama", "Comedy"],
+    writeBackType: "recommend",
+    writeBackDelay: "1h",
+    cursorOptions: { n: 3, offset: 0 },
+  });
+  expect(recommendations).toHaveLength(3);
+  for (const recommendation of recommendations) {
+    const item = await client.getItem(recommendation.Id);
+    expect(
+      item.Categories?.some(
+        (category) => category === "Drama" || category === "Comedy",
+      ),
+    ).toBe(true);
+  }
+});


### PR DESCRIPTION
## Summary
- use the current `/api/recommend/{user-id}` endpoint
- support multiple categories through repeated `category` query parameters
- preserve single-category calls while supporting write-back, `n`, and `offset`
- keep scored responses with `X-API-Version: 2`

## Tests
- `corepack yarn workspace gorsejs test --runInBand`
- `corepack yarn workspace gorsejs lint`
- `corepack yarn workspace gorsejs build`
